### PR TITLE
feat: add math representations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720025378,
+        "narHash": "sha256-zlIdj0oLvMEHlllP/7tvY+kE987xsN4FPux6WHSOh00=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "087e08a41009bf083d51ab35d8e30b1b7eafa7b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720058333,
+        "narHash": "sha256-gM2RCi5XkxmcsZ44pUkKIYBiBMfZ6u7MdcZcykmccrs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6842b061970bf96965d66fcc86a28e1f719aae95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "graphing calculator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        craneLib = crane.mkLib pkgs;
+
+        commonArgs = {
+          src = craneLib.cleanCargoSource ./.;
+          strictDeps = true;
+
+          buildInputs = with pkgs; [
+            pkg-config
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            fontconfig
+            wayland-scanner.out
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXrandr
+            xorg.libXi
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+          ];
+        };
+
+        queercalc = craneLib.buildPackage (commonArgs // {
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath commonArgs.buildInputs}";
+        });
+      in
+      {
+        checks = {
+          inherit queercalc;
+        };
+
+        packages.default = queercalc;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = queercalc;
+        };
+
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+          packages = [];
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath commonArgs.buildInputs}";
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,9 @@
             xorg.libXcursor
             xorg.libXrandr
             xorg.libXi
+            freeglut
+            libGL
+            libxkbcommon
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             pkgs.libiconv
           ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
         "My egui App",
         native_options,
         Box::new(|cc| Box::new(MyEguiApp::new(cc))),
-    );
+    ).expect("eframe::run_native");
 }
 
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 use eframe::egui::{self, CentralPanel, Visuals};
 use egui_plotter::EguiBackend;
 use plotters::prelude::*;
+pub mod math;
 
 fn main() {
     let native_options = eframe::NativeOptions::default();

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,4 @@
+pub mod parse;
+pub mod tok;
+pub mod tex;
+pub mod render;

--- a/src/math/parse.rs
+++ b/src/math/parse.rs
@@ -1,0 +1,179 @@
+use super::tok::*;
+
+// TODO switch to arena allocator
+
+struct TokenStream<'t> {
+    toks: &'t [Token],
+    idx: usize,
+}
+
+fn infix_info(c: char) -> Option<(u8, u8, fn(Box<MathTree>, Box<MathTree>) -> MathTree)> {
+    Some(match c {
+        '+' => (50, 60, MathTree::Plus),
+        '-' => (50, 60, MathTree::Sub),
+        '*' => (70, 80, MathTree::Mul),
+        _ => return None,
+    })
+}
+
+macro_rules! matchxtract {
+    ($val:expr, $p:pat => $e:expr) => {
+        match $val {
+            $p => Some($e),
+            _ => None,
+        }
+    };
+}
+
+type Result<T> = std::result::Result<T, ParseError>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    ExpectingPrimary,
+}
+
+impl<'t> TokenStream<'t> {
+    fn peek(&self) -> Option<&'t Token> {
+        self.toks.get(self.idx)
+    }
+
+    fn advance(&mut self) -> Option<&Token> {
+        self.idx += 1;
+        self.toks.get(self.idx - 1)
+    }
+
+    fn sniff<F, Ret>(&mut self, cond: F) -> Option<Ret>
+    where
+        F: FnOnce(&'t Token) -> Option<Ret>,
+    {
+        self.peek().and_then(cond)
+    }
+
+    fn eat<F, Ret>(&mut self, cond: F) -> Option<Ret>
+    where
+        F: FnOnce(&'t Token) -> Option<Ret>,
+    {
+        self.sniff(cond).inspect(|_| {
+            self.advance();
+        })
+    }
+
+    fn prim(&mut self) -> Option<Result<MathTree>> {
+        if let Some(res) = self.eat(|t| {
+            Some(match t {
+                Token::Frac(top, bot) => parse(top)
+                    .and_then(|top| parse(bot).map(|bot| (top, bot)))
+                    .map(|(top, bot)| MathTree::Div(Box::new(top), Box::new(bot))),
+                &Token::Glyph(c) if c.is_alphabetic() => Ok(MathTree::Var(c)),
+                _ => return None,
+            })
+        }) {
+            return Some(res);
+        }
+
+        let mut s = String::new();
+        while let Some(c) = self.eat(|t| matchxtract!(t, &Token::Glyph(d @ ('0'..='9' | '.')) => d))
+        {
+            s.push(c);
+        }
+        s.parse::<f64>().ok().map(MathTree::Num).map(Ok)
+    }
+
+    fn sniff_op(&mut self) -> Option<char> {
+        self.sniff(|t| matchxtract!(t, &Token::Glyph(c @ ('+' | '-')) => c))
+    }
+
+    fn expr_prec(&mut self, min_prec: u8) -> Result<MathTree> {
+        // TODO prefix and postfix operators
+        let mut lhs = self.prim().ok_or(ParseError::ExpectingPrimary)??;
+        while self.peek().is_some() {
+            if let Some(op) = self.sniff_op() {
+                if let Some((lp, rp, cons)) = infix_info(op) {
+                    if lp >= min_prec {
+                        self.advance();
+                        let rhs = self.expr_prec(rp)?;
+                        lhs = cons(Box::new(lhs), Box::new(rhs));
+                        continue;
+                    }
+                }
+                break;
+            } else {
+                // (term) (sup) is power-of
+                if let Some(k) = self.eat(|t| matchxtract!(t, Token::Sup(k) => k)) {
+                    let rhs = parse(k)?;
+                    lhs = MathTree::Pow(Box::new(lhs), Box::new(rhs));
+                    continue;
+                }
+                // (term) (term) is multiplication
+                let rhs = self.prim().ok_or(ParseError::ExpectingPrimary)??;
+                lhs = MathTree::Mul(Box::new(lhs), Box::new(rhs));
+                continue;
+            }
+        }
+        Ok(lhs)
+    }
+
+    fn entry(&mut self) -> Result<MathTree> {
+        self.expr_prec(0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MathTree {
+    Plus(Box<MathTree>, Box<MathTree>),
+    Mul(Box<MathTree>, Box<MathTree>),
+    Sub(Box<MathTree>, Box<MathTree>),
+    Div(Box<MathTree>, Box<MathTree>),
+    Pow(Box<MathTree>, Box<MathTree>),
+    Num(f64),
+    Var(char),
+}
+
+pub fn parse(toks: &[Token]) -> Result<MathTree> {
+    TokenStream { idx: 0, toks }.entry()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::keysim;
+
+    macro_rules! b {
+        ($p:ident, $($e:expr),*) => {
+            MathTree::$p($(Box::new($e)),*)
+        }
+    }
+
+    #[test]
+    fn basic() {
+        use MathTree::*;
+        use Token::*;
+        assert_eq!(
+            parse(&[Glyph('a'), Glyph('+'), Glyph('b')]).unwrap(),
+            Plus(Box::new(Var('a')), Box::new(Var('b')))
+        );
+        assert_eq!(
+            parse(&keysim!("a+bc")).unwrap(),
+            Plus(
+                Box::new(Var('a')),
+                Box::new(Mul(Box::new(Var('b')), Box::new(Var('c'))))
+            )
+        );
+        assert_eq!(
+            parse(&keysim!("ab+c")).unwrap(),
+            Plus(
+                Box::new(Mul(Box::new(Var('a')), Box::new(Var('b')))),
+                Box::new(Var('c'))
+            )
+        );
+        assert_eq!(
+            parse(&keysim!("3+a^b")).unwrap(),
+            b!(Plus, Num(3.), b!(Pow, Var('a'), Var('b')))
+        );
+        assert_eq!(
+            parse(&keysim!("18591+581")).unwrap(),
+            b!(Plus, Num(18591.), Num(581.))
+        );
+    }
+}

--- a/src/math/render.rs
+++ b/src/math/render.rs
@@ -1,0 +1,4 @@
+use super::tok::*;
+
+struct GlyphRender;
+

--- a/src/math/tex.rs
+++ b/src/math/tex.rs
@@ -1,0 +1,59 @@
+use super::tok::*;
+
+fn serialize(toks: &[Token], out: &mut String) {
+    for tok in toks {
+        match tok {
+            &Token::Glyph(r) => {
+                if r == '\\' {
+                    *out += "\\backslash";
+                } else {
+                    out.push(r);
+                }
+            }
+            Token::Sup(kids) => {
+                *out += "^{";
+                serialize(kids, out);
+                out.push('}');
+            }
+            Token::Frac(c1, c2) => {
+                *out += "\\frac{";
+                serialize(c1, out);
+                *out += "}{";
+                serialize(c2, out);
+                *out += "}";
+            }
+        }
+    }
+}
+
+pub fn to_tex(toks: &[Token]) -> String {
+    let mut s = String::new();
+    serialize(toks, &mut s);
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        use Token::*;
+        let toks = vec![
+            Glyph('-'),
+            Glyph('r'),
+            Glyph('e'),
+            Sup(vec![
+                Glyph('2'),
+                Sup(vec![Glyph('2')]),
+                Glyph('i'),
+                Glyph('t'),
+            ]),
+            Glyph('+'),
+            Glyph('c'),
+        ];
+
+        let res = to_tex(&toks);
+        assert_eq!(res, "-re^{2^{2}it}+c");
+    }
+}

--- a/src/math/tok.rs
+++ b/src/math/tok.rs
@@ -1,0 +1,461 @@
+//! Internal tokenized representation of math formulae. 1:1 with the visual representation.
+//! Consists of a tree of tokens with glyphs as leaves.
+
+use std::{ops::Range, ptr::NonNull};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    /// A single, visible glyph on screen, e.g. 'x', '2', or '+'.
+    Glyph(char),
+    /// A list of tokens that are superscripted, e.g. `[Glyph('x'), Sup([Glyph('2')]]` -> x^2.
+    Sup(Vec<Token>),
+    /// (Numerator, denominator).
+    Frac(Vec<Token>, Vec<Token>),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TokenType {
+    Glyph,
+    Sup,
+    Frac,
+}
+
+impl From<&Token> for TokenType {
+    fn from(value: &Token) -> Self {
+        match value {
+            Token::Glyph(_) => TokenType::Glyph,
+            Token::Sup(_) => TokenType::Sup,
+            Token::Frac(_, _) => TokenType::Frac,
+        }
+    }
+}
+
+fn valid_var_name(c: char) -> bool {
+    c.is_alphabetic()
+}
+
+#[derive(Debug)]
+pub struct MathTokenTree {
+    top: Box<Vec<Token>>,
+    cursor: Cursor,
+}
+
+impl MathTokenTree {
+    pub fn keypress(&mut self, key: Key) {
+        match key {
+            Key::Left => self.cursor.move_left(),
+            Key::Right => self.cursor.move_right(),
+            Key::Down => self.cursor.move_down(),
+            Key::Text('^') => self.cursor.insert(Token::Sup(Vec::new())),
+            Key::Text('/') => {
+                let last_prim = self.cursor.reverse_steal_prim();
+                let has_last_prim = !last_prim.is_empty();
+                self.cursor.insert(Token::Frac(last_prim, vec![]));
+                if has_last_prim {
+                    // go to denominator of the fraction
+                    self.cursor.move_down();
+                }
+            }
+            Key::Text(c) => self.cursor.insert(Token::Glyph(c)),
+        }
+    }
+
+    pub fn from_toks(toks: Vec<Token>) -> Self {
+        let mut toks = Box::new(toks);
+        // SAFETY: err, i think this should guarantee it is kept in place?
+        let ptr = Box::as_mut(&mut toks);
+        let ptr = NonNull::from(ptr);
+        MathTokenTree {
+            top: toks,
+            cursor: Cursor {
+                index: 0,
+                top: ptr,
+                path: Vec::new(),
+            },
+        }
+    }
+
+    pub fn toks(&self) -> &[Token] {
+        &self.top
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Cursor {
+    /// A reference to the top-level list of nodes.
+    top: NonNull<Vec<Token>>,
+    /// Stack of tuples representing how far we are down the tree.
+    /// Each element is a tuple of (parent index, parent type, children list).
+    ///
+    /// SAFETY: All mutability functions only affect the *current* region.
+    /// This ensures the parents are not modified.
+    path: Vec<(usize, NonNull<Vec<Token>>)>,
+    /// Where the cursor is in the current node.
+    /// This represents the index of the token to the *right* of the cursor.
+    /// ```md
+    /// [  Glyph('2'),  Glyph('a'),  Glyph('b')  ]
+    ///  ^index 0     ^index 1     ^index 2    ^index 3
+    /// ```
+    index: usize,
+}
+
+impl Cursor {
+    /// SAFETY: these pointers always point to valid `Vec`s
+    fn current_region(&self) -> &Vec<Token> {
+        if let Some(&(_, region)) = self.path.last() {
+            unsafe { region.as_ref() }
+        } else {
+            unsafe { self.top.as_ref() }
+        }
+    }
+
+    /// SAFETY: these pointers always point to valid `Vec`s
+    fn current_region_mut(&mut self) -> &mut Vec<Token> {
+        if let Some(&(_, mut region)) = self.path.last() {
+            unsafe { region.as_mut() }
+        } else {
+            unsafe { self.top.as_mut() }
+        }
+    }
+
+    fn parent(&self) -> Option<&Token> {
+        if let Some(&(parent_idx, _)) = self.path.last() {
+            let mut ptr = self.top;
+            if self.path.len() >= 2 {
+                if let Some(&(_, parent_region)) = self.path.get(self.path.len() - 2) {
+                    ptr = parent_region;
+                }
+            }
+            let parent_region = unsafe { ptr.as_ref() };
+            Some(&parent_region[parent_idx])
+        } else {
+            None
+        }
+    }
+
+    /// Jump to the left of the parent.
+    fn jump_left_of_parent(&mut self) {
+        if let Some(&(parent_idx, _)) = self.path.last() {
+            // the parent should be on the right
+            self.index = parent_idx;
+            self.path.pop();
+        }
+    }
+    /// Jump to the right of the parent.
+    fn jump_right_of_parent(&mut self) {
+        if let Some(&(parent_idx, _)) = self.path.last() {
+            // the parent should be on the left, so `parent_idx+1` should be on the right
+            self.index = parent_idx + 1;
+            self.path.pop();
+        }
+    }
+
+    /// Jump to the left bound of the current region.
+    fn jump_left_bound(&mut self) {
+        self.index = 0;
+    }
+
+    /// Jump to the right bound of the current region.
+    fn jump_right_bound(&mut self) {
+        // note: [last valid index] + 1 is fine here,
+        // because that is the index of an element (that would be) to the *right* of the cursor
+        self.index = self.current_region().len();
+    }
+
+    /// Enter a node, ending up at the *left* of that node's region.
+    /// Returns `true` if a node was actually entered.
+    fn enter_node(&mut self, idx: usize) -> bool {
+        let region = self.current_region_mut();
+        if idx >= region.len() {
+            // already at the far-right of the region,
+            // no node to enter
+            return false;
+        }
+        let ptr;
+        match &mut region[idx] {
+            Token::Glyph(_) => return false,
+            Token::Sup(children) | Token::Frac(children, _) => {
+                ptr = NonNull::from(children);
+            }
+        }
+        self.path.push((idx, ptr));
+        self.index = 0;
+        return true;
+    }
+
+    fn move_left(&mut self) {
+        if self.index > 0 {
+            let left_idx = self.index - 1;
+            if self.enter_node(left_idx) {
+                self.jump_right_bound();
+            } else {
+                // Could not enter node, skip it instead
+                self.index = left_idx;
+            }
+        } else {
+            // escape the current node (if any)
+            self.jump_left_of_parent();
+        }
+    }
+
+    fn move_right(&mut self) {
+        if self.index < self.current_region().len() {
+            if self.enter_node(self.index) {
+                self.jump_left_bound();
+            } else {
+                // Could not enter node, skip it instead
+                self.index += 1;
+            }
+        } else {
+            // escape the current node (if any)
+            self.jump_right_of_parent();
+        }
+    }
+
+    fn move_down(&mut self) {
+        // move to denominator of fraction, preserving relative index
+        if matches!(self.parent(), Some(Token::Frac(_, _))) {
+            let old_idx = self.index;
+            self.jump_left_of_parent();
+            let parent_idx = self.index;
+            let Token::Frac(_, bot) = &mut self.current_region_mut()[parent_idx] else {
+                unreachable!("earlier checked for Frac")
+            };
+            let bot_len = bot.len();
+            let bot = NonNull::from(bot);
+            self.path.push((parent_idx, bot));
+            self.index = old_idx.min(bot_len);
+        }
+    }
+
+    /// Delete node to the left of the cursor.
+    /// If no such node exists, move the rest of the nodes in the current
+    /// region up one level, then delete the parent.
+    fn delete(&mut self) {
+        todo!()
+    }
+
+    /// Parses a primary expression in reverse. Tries to find
+    /// a primary expression *just before* the cursor.
+    /// Returns the range of indices in the current region
+    /// that contains the primary expression (or an empty range if none).
+    ///
+    /// (This is used for inputting fractions.)
+    fn reverse_parse_prim(&self) -> Range<usize> {
+        if self.index == 0 {
+            return 0..0;
+        }
+        let region = self.current_region();
+        // if we are consuming the glyphs of a number
+        // instead of looking for variable primary expressions
+        let mut consuming_number = false;
+        let mut rev_idx = self.index - 1;
+        loop {
+            if consuming_number {
+                if !matches!(region[rev_idx], Token::Glyph('0'..='9')) {
+                    rev_idx += 1;
+                    break;
+                }
+            } else {
+                match region[rev_idx] {
+                    Token::Glyph(c) => {
+                        if valid_var_name(c) {
+                            break;
+                        } else if c.is_ascii_digit() || c == '.' {
+                            consuming_number = true;
+                        }
+                    }
+                    Token::Frac(_, _) => break,
+                    Token::Sup(_) => { /* attached to a prim that is further behind */ }
+                }
+            }
+            if rev_idx == 0 {
+                break;
+            }
+            rev_idx -= 1;
+        }
+        rev_idx..self.index
+    }
+
+    /// Finds the primary expression directly before the cursor (if any),
+    /// removes it, and returns it in the provided vector.
+    fn reverse_steal_prim(&mut self) -> Vec<Token> {
+        let range = self.reverse_parse_prim();
+        self.index -= range.len();
+        let res = self.current_region_mut().drain(range).collect();
+        res
+    }
+
+    /// Insert a token at the current cursor position,
+    /// moving the cursor to the right once afterward.
+    fn insert(&mut self, tok: Token) {
+        let index = self.index;
+        let region = self.current_region_mut();
+        region.insert(index, tok);
+        self.move_right();
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Key {
+    Left,
+    Right,
+    Down,
+    /// Any 'text' key, i.e. ASCII printables.
+    Text(char),
+}
+
+pub fn apply_keystroke_seq(t: &mut MathTokenTree, s: &str) {
+    for c in s.chars() {
+        t.keypress(Key::Text(c));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Token::*;
+
+    #[macro_export]
+    macro_rules! keysim {
+        ($($e:tt),*) => {
+            {
+                let mut t = MathTokenTree::from_toks(vec![]);
+                $(keysim!(# t $e);)*
+                Vec::from(t.toks())
+            }
+        };
+        (# $v:ident $e:literal) => {
+            apply_keystroke_seq(&mut $v, $e)
+        };
+        (# $v:ident $e:ident) => {
+            $v.keypress(Key::$e)
+        }
+    }
+
+    #[test]
+    fn frac() {
+        assert_eq!(
+            keysim!("/3", Down, "4"),
+            vec![Frac(vec![Glyph('3')], vec![Glyph('4')])]
+        );
+        assert_eq!(
+            keysim!("3/4"),
+            vec![Frac(vec![Glyph('3')], vec![Glyph('4')])]
+        );
+        assert_eq!(
+            keysim!("158^2", Right, "/4"),
+            vec![Frac(
+                vec![Glyph('1'), Glyph('5'), Glyph('8'), Sup(vec![Glyph('2')])],
+                vec![Glyph('4')]
+            )]
+        );
+        assert_eq!(
+            keysim!("yx^2", Right, "/14"),
+            vec![
+                Glyph('y'),
+                Frac(
+                    vec![Glyph('x'), Sup(vec![Glyph('2')])],
+                    vec![Glyph('1'), Glyph('4')]
+                )
+            ]
+        );
+        assert_eq!(
+            keysim!("x^6/3"),
+            vec![
+                Glyph('x'),
+                Sup(vec![Frac(vec![Glyph('6')], vec![Glyph('3')])])
+            ]
+        );
+        assert_eq!(
+            keysim!("3/4/5"),
+            vec![Frac(
+                vec![Glyph('3')],
+                vec![Frac(vec![Glyph('4')], vec![Glyph('5')])]
+            )]
+        );
+    }
+
+    #[test]
+    fn basic() {
+        let toks = vec![Glyph('e'), Sup(vec![Glyph('i')])];
+        let mut f = MathTokenTree::from_toks(toks);
+        // |e^{i}
+        f.keypress(Key::Text('r')); // r|e^{i}
+        f.keypress(Key::Right); // re|^{i}
+        f.keypress(Key::Right); // re^{|i}
+        f.keypress(Key::Right); // re^{i|}
+        f.keypress(Key::Text('t')); // re^{it|}
+        assert_eq!(
+            f.toks(),
+            vec![Glyph('r'), Glyph('e'), Sup(vec![Glyph('i'), Glyph('t')])]
+        );
+        f.keypress(Key::Left); // re^{i|t}
+        f.keypress(Key::Left); // re^{|it}
+        f.keypress(Key::Text('2')); // re^{2|it}
+        f.keypress(Key::Text('^')); // re^{2^{|}it}
+        f.keypress(Key::Text('2')); // re^{2^{2|}it}
+        assert_eq!(
+            f.toks(),
+            vec![
+                Glyph('r'),
+                Glyph('e'),
+                Sup(vec![
+                    Glyph('2'),
+                    Sup(vec![Glyph('2')]),
+                    Glyph('i'),
+                    Glyph('t')
+                ])
+            ]
+        );
+        f.keypress(Key::Left); // re^{2^{|2}it}
+        f.keypress(Key::Left); // re^{2|^{2}it}
+        f.keypress(Key::Left); // re^{|2^{2}it}
+        f.keypress(Key::Left); // re|^{2^{2}it}
+        f.keypress(Key::Left); // r|e^{2^{2}it}
+        f.keypress(Key::Left); // |re^{2^{2}it}
+        f.keypress(Key::Text('-')); // -|re^{2^{2}it}
+        assert_eq!(
+            f.toks(),
+            vec![
+                Glyph('-'),
+                Glyph('r'),
+                Glyph('e'),
+                Sup(vec![
+                    Glyph('2'),
+                    Sup(vec![Glyph('2')]),
+                    Glyph('i'),
+                    Glyph('t')
+                ]),
+            ]
+        );
+        f.keypress(Key::Right); // -r|e^{2^{2}it}
+        f.keypress(Key::Right); // -re|^{2^{2}it}
+        f.keypress(Key::Right); // -re^{|2^{2}it}
+        f.keypress(Key::Right); // -re^{2|^{2}it}
+        f.keypress(Key::Right); // -re^{2^{|2}it}
+        f.keypress(Key::Right); // -re^{2^{2|}it}
+        f.keypress(Key::Right); // -re^{2^{2}|it}
+        f.keypress(Key::Right); // -re^{2^{2}i|t}
+        f.keypress(Key::Right); // -re^{2^{2}it|}
+        f.keypress(Key::Right); // -re^{2^{2}it}|
+        f.keypress(Key::Text('+'));
+        f.keypress(Key::Text('c'));
+        assert_eq!(
+            f.toks(),
+            vec![
+                Glyph('-'),
+                Glyph('r'),
+                Glyph('e'),
+                Sup(vec![
+                    Glyph('2'),
+                    Sup(vec![Glyph('2')]),
+                    Glyph('i'),
+                    Glyph('t')
+                ]),
+                Glyph('+'),
+                Glyph('c'),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
just ignore the macros and the `unsafe` and the long type signatures and the violation of the unique borrow rule