### PR TITLE
Add fedora compilation dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # QueerCalc
 desmos but better and in rust and also queer
+
+# Dependencies
+## Fedora
+`fontconfig-devel`


### PR DESCRIPTION
Does what it says in the title. Needed this for the current main branch to compile on Fedora 40 for me. Might be a good idea to look into the dependencies for other distros in the future.